### PR TITLE
Fixes UTF8 output length by accounting for variable header size

### DIFF
--- a/src/cb0r.c
+++ b/src/cb0r.c
@@ -168,6 +168,7 @@ uint8_t *cb0r(uint8_t *start, uint8_t *stop, uint32_t skip, cb0r_t result)
     type = (start[0] >> 5);
 
   // done done, extract value if result requested
+  uint8_t headerSz = size + 1;
   if(!skip)
   {
     if(!result) return end;
@@ -217,7 +218,7 @@ uint8_t *cb0r(uint8_t *start, uint8_t *stop, uint32_t skip, cb0r_t result)
       case CB0R_BYTE:
       case CB0R_UTF8: {
         if(count == CB0R_STREAM) result->count = count;
-        else result->length = end - (start + 1);
+        else result->length = end - (start + headerSz);
       } break;
 
       case CB0R_ARRAY:
@@ -256,7 +257,7 @@ uint8_t *cb0r(uint8_t *start, uint8_t *stop, uint32_t skip, cb0r_t result)
         if(result->type < CB0R_ERR) result->type = CB0R_ERR;
       }
     }
-    result->header = size + 1;
+    result->header = headerSz;
     return end;
   }
 


### PR DESCRIPTION
`cb0r` was failing to decode data whose key was >23 bytes. This is because 23 is the largest value which does not include a length prefix, per the cbor spec.

Here is an example of the issue:

```
#include "cb0r.h"
#include "string.h"
#include "stdio.h"
#define NOT_TOO_LONG_KEY "HelloIHaveAVeryLongName"
#define TOO_LONG_KEY "HelloIHaveAVeryLongName!"
int main() {
  // { "HelloIHaveAVeryLongName": 0 }
  uint8_t notTooLong[26] = {
    0xa1, 0x77, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x49, 
    0x48, 0x61, 0x76, 0x65, 0x41, 0x56, 0x65, 0x72, 
    0x79, 0x4c, 0x6f, 0x6e, 0x67, 0x4e, 0x61, 0x6d,
    0x65, 0x00, 
  };
  // { "HelloIHaveAVeryLongName!": 0 }
  uint8_t tooLong[28] = {
    0xa1, 0x78, 0x18, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 
    0x49, 0x48, 0x61, 0x76, 0x65, 0x41, 0x56, 0x65, 
    0x72, 0x79, 0x4c, 0x6f, 0x6e, 0x67, 0x4e, 0x61, 
    0x6d, 0x65, 0x21, 0x00
  };
  cb0r_s result1 = {0};
  cb0r_s data1 = {0};
  if (!cb0r_read(notTooLong, sizeof(notTooLong), &data1))
    return -1;
  bool found = cb0r_find(&data1, CB0R_UTF8, 23, (uint8_t*)NOT_TOO_LONG_KEY, &result1);
  printf("Found not too long key: %d\n\r", found);
  cb0r_s result2 = {0};
  cb0r_s data2 = {0};
  if (!cb0r_read(tooLong, sizeof(tooLong), &data2))
    return -1;
  // FUNNY ENOUGH THIS PASSES IF I USE 25 INSTEAD OF 24
  bool found2 = cb0r_find(&data2, CB0R_UTF8, 24, (uint8_t*)TOO_LONG_KEY, &result2);
  printf("Found too long key: %d", found2);
  return 0;
}
```

Note the prefix of the 23-character key is `0x77`, while that of the 24-character key is `0x78, 0x18`, where 0x18 indicates the length of 24.

Failing to account for this extra byte led to `result->length` being invalid, which led to a decoding failure. Simply capturing this header size results in proper decoding.

*Note that we only needed to fix this for UTF8 types and while we have smoke-tested a large range of types and sizes, there are some types we do not use so similar issues may be present in other areas of the code.*